### PR TITLE
Task - FE - Make Pinia getters writable in unit tests

### DIFF
--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -4,7 +4,7 @@
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-
+    "skipLibCheck": false,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/client/tsconfig.vitest.json
+++ b/client/tsconfig.vitest.json
@@ -1,11 +1,10 @@
 {
   "extends": "./tsconfig.app.json",
-  "include": ["src/**/__tests__/*", "env.d.ts"],
+  "include": ["src/**/*.spec.ts", "env.d.ts", "types/pinia-vitest.d.ts"],
   "exclude": [],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
-
     "lib": [],
-    "types": ["node", "jsdom"]
+    "types": ["node", "jsdom", "vitest/globals"]
   }
 }

--- a/client/types/pinia-vitest.d.ts
+++ b/client/types/pinia-vitest.d.ts
@@ -1,0 +1,38 @@
+import * as pinia from 'pinia'
+import type { Mock } from 'vitest'
+import type { ComputedRef } from 'vue'
+
+type WritableGetters<Getters> = {
+  [K in keyof Getters]: Getters[K] extends ComputedRef<infer T> ? T : never
+}
+
+declare type Method = (...args: any[]) => any
+
+type MockActions<Actions> = {
+  [A in keyof Actions]: Actions[A] extends Method ? Mock<Actions[A]> : Actions[A]
+}
+
+declare interface SetupStoreHelpers {
+  action: <Fn extends Method>(fn: Fn) => Fn
+}
+
+declare module 'pinia' {
+  // override defineStore setup store declaration
+  // to make getters writable and actions mockable in unit tests
+  export function defineStore<Id extends string, SS>(
+    id: Id,
+    storeSetup: (helpers: SetupStoreHelpers) => SS,
+    options?: DefineSetupStoreOptions<
+      Id,
+      _ExtractStateFromSetupStore<SS>,
+      _ExtractGettersFromSetupStore<SS>,
+      _ExtractActionsFromSetupStore<SS>
+    >,
+  ): StoreDefinition<
+    Id,
+    _ExtractStateFromSetupStore<SS>,
+    Record<string, never>,
+    WritableGetters<_ExtractGettersFromSetupStore<SS>> &
+      MockActions<_ExtractActionsFromSetupStore<SS>>
+  >
+}


### PR DESCRIPTION
Override the Pinia library types in unit tests to allow store computed values to be overridden and actions to be spied on.

Some background:
The `createTestingPinia` function from the `@pinia/testing` library makes store getters/computed writable and converts actions to mock functions. However, the typing for this are missing in the library which causes type errors in the unit tests. To workaround this, one usually needs to wrap the store in some function to change the types or manually tell the TS compiler to ignore the errors.